### PR TITLE
Use the appropriate way to retrieve the managers of a meeting

### DIFF
--- a/fedocal/__init__.py
+++ b/fedocal/__init__.py
@@ -539,7 +539,8 @@ def view_meeting_page(meeting_id, full):
     editor = is_admin()
     if not editor:
         if flask.g.fas_user and \
-                flask.g.fas_user.username in meeting.meeting_manager:
+                flask.g.fas_user.username in Meeting.get_managers(
+                    SESSION, meeting_id):
             editor = True
     return flask.render_template(
         'view_meeting.html',


### PR DESCRIPTION
In the previous way, if the manager was "abc" and the nick "ab" the
check was returning True instead of False.
