### PR TITLE
Specify the latest python-fedora in requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ flask-wtf
 flask
 kitchen
 python-dateutil <= 1.5
-python-fedora
+https://github.com/fedora-infra/python-fedora/archive/develop.zip
 pytz
 sqlalchemy
 vobject


### PR DESCRIPTION
Ran into a bit of trouble trying to set up fedocal in a virtualenv.  This helps get around it.
