### PR TITLE
Add a local copy of nosetests allowing to run the test suite on EL6

### DIFF
--- a/nosetests
+++ b/nosetests
@@ -1,0 +1,9 @@
+#!/usr/bin/python
+# EASY-INSTALL-ENTRY-SCRIPT: 'nose==0.10.4','console_scripts','nosetests'
+__requires__ = ['nose==0.10.4', 'SQLAlchemy >= 0.7', 'jinja2 >= 2.4']
+import sys
+from pkg_resources import load_entry_point
+
+sys.exit(
+   load_entry_point('nose==0.10.4', 'console_scripts', 'nosetests')()
+)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-FEDOCAL_CONFIG=../tests/fedocal_test.cfg PYTHONPATH=fedocal nosetests --with-coverage --cover-erase --cover-package=fedocal $*
+FEDOCAL_CONFIG=../tests/fedocal_test.cfg PYTHONPATH=fedocal ./nosetests --with-coverage --cover-erase --cover-package=fedocal $*


### PR DESCRIPTION
Append to the local nosetests the correct requirements to run the test
suite on EL6 with the appropriate version on SQLAlchemy.
