### PR TITLE
Fix typos or missing logic for the meeting_date_end

### DIFF
--- a/fedocal/__init__.py
+++ b/fedocal/__init__.py
@@ -611,8 +611,12 @@ def edit_meeting(meeting_id):
                 meetingobj.meeting_date = meetingobj.meeting_date + \
                     datetime.timedelta(
                         days=meetingobj.recursion_frequency * cnt)
+                meetingobj.meeting_date_end = meetingobj.meeting_date_end + \
+                    datetime.timedelta(
+                        days=meetingobj.recursion_frequency * cnt)
                 cnt = cnt + 1
             meeting = meetingobj
+
         if not fedocallib.is_date_in_future(
                 meeting.meeting_date,
                 meeting.meeting_time_start):

--- a/fedocal/forms.py
+++ b/fedocal/forms.py
@@ -166,9 +166,9 @@ class AddMeetingForm(wtf.Form):
                 meeting.meeting_time_start.hour,
                 meeting.meeting_time_start.minute, 0)
             stopdt = datetime(
-                meeting.meeting_date.year,
-                meeting.meeting_date.month,
-                meeting.meeting_date.day,
+                meeting.meeting_date_end.year,
+                meeting.meeting_date_end.month,
+                meeting.meeting_date_end.day,
                 meeting.meeting_time_stop.hour,
                 meeting.meeting_time_stop.minute, 0)
 


### PR DESCRIPTION
This resulted in strange situation where one would edit a meeting of a recursion (in the
future), see the start date correct (in the future) and the end date incorrect (of the
original meeting, so in the past).
