### PR TITLE
Make alembic upgrade script compatible with MySQL

### DIFF
--- a/alembic/versions/2a554683048e_rename_managers_as_e.py
+++ b/alembic/versions/2a554683048e_rename_managers_as_e.py
@@ -16,10 +16,17 @@ import sqlalchemy as sa
 
 
 def upgrade():
-    op.alter_column('calendars', column_name='calendar_manager_group',
-                    name='calendar_editor_group')
+    op.alter_column('calendars',
+                    column_name='calendar_manager_group',
+                    name='calendar_editor_group',
+                    existing_type=sa.String(100),
+                    existing_nullable=True
+                    )
 
 
 def downgrade():
     op.alter_column('calendars', column_name='calendar_editor_group',
-                    name='calendar_manager_group')
+                    name='calendar_manager_group',
+                    existing_type=sa.String(100),
+                    existing_nullable=True
+                )


### PR DESCRIPTION
According to the alembic documentation "MySQL has special requirements" so be it.
