### PR TITLE
Mark full day meeting as transparent in the iCal output

### DIFF
--- a/fedocal/fedocallib/__init__.py
+++ b/fedocal/fedocallib/__init__.py
@@ -659,6 +659,7 @@ def add_meeting_to_vcal(ical, meeting):
     if meeting.full_day:
         start.value = meeting.meeting_date
         stop.value = meeting.meeting_date_end
+        entry.add('transp').value = 'TRANSPARENT'
     else:
         meeting.meeting_time_start = meeting.meeting_time_start.replace(
             tzinfo=utc)


### PR DESCRIPTION
This way they do not appear to consume time
