### PR TITLE
Further fedmsg configuration for the cronjob.

### DIFF
--- a/fedocal_cron.py
+++ b/fedocal_cron.py
@@ -53,6 +53,8 @@ def fedmsg_init():
 
     config = fedmsg.config.load_config()
     config['active'] = True
+    config['name'] = 'relay_inbound'
+    config['cert_prefix'] = 'fedocal'
     fedmsg.init(**config)
 
 


### PR DESCRIPTION
fedmsg needs this info to point the cronjob at the fedmsg-relay (instead of doing the normal passive publishing like the webapp does)
