### PR TITLE
Fix the edition of recursive meetings to have three buttons instead of two

### DIFF
--- a/fedocal/__init__.py
+++ b/fedocal/__init__.py
@@ -582,6 +582,7 @@ def edit_meeting(meeting_id):
     # pylint: disable=E1101
     if form.validate_on_submit():
         tzone = form.meeting_timezone.data or tzone
+        action = flask.request.form.get('action', 'Edit')
         try:
             fedocallib.edit_meeting(
                 session=SESSION,
@@ -602,7 +603,7 @@ def edit_meeting(meeting_id):
                 remind_when=form.remind_when.data,
                 remind_who=form.remind_who.data,
                 full_day=form.full_day.data,
-                edit_all_meeting=form.recursive_edit.data,
+                edit_all_meeting=action == 'Edit all',
                 admin=is_admin())
         except FedocalException, err:
             flask.flash(err, 'warnings')

--- a/fedocal/forms.py
+++ b/fedocal/forms.py
@@ -149,10 +149,6 @@ class AddMeetingForm(wtf.Form):
         'End date',
         [wtforms.validators.optional()])
 
-    # Recursive edit
-    recursive_edit = wtforms.BooleanField(
-        'Yes I want to edit all the meetings')
-
     # Reminder
     remind_when = wtforms.SelectField(
         'Send reminder',

--- a/fedocal/templates/default/edit_meeting.html
+++ b/fedocal/templates/default/edit_meeting.html
@@ -49,20 +49,16 @@
             {{ render_field_in_row(form.remind_who) }}
         </table>
 
-        {% if meeting.recursion_frequency %}
-            <h4>Edit all?</h4>
-            <p>This meeting is a recursive meeting, by default your
-            changes will only affect this meeting unless you explecitely
-            say otherwise:
-            </p>
-            {{ render_field_invert(form.recursive_edit) }}
-        {% endif %}
+        {{ form.csrf_token }}
 
         <p class="buttons indent">
-            <input type="submit" class="submit positive button" value="Edit">
-            <input type="button" value="Cancel" class="button" onclick="history.back();">
-            {{ form.csrf_token }}
+            <input type="submit" name="action" class="submit positive button" value="Edit"/>
+        {% if meeting.recursion_frequency %}
+            <input type="submit" name="action" class="submit positive button" value="Edit all"/>
+        {% endif %}
+            <input type="button" name="action" value="Cancel" class="button" onclick="history.back();"/>
         </p>
+
     </form>
 </section>
 {% endblock %}


### PR DESCRIPTION
Regular meetings have the two buttons model:
[Edit] [Cancel]
Recursive meetings have the three buttons model:
[Edit] [Edit all] [Cancel]

Fixes https://fedorahosted.org/fedocal/ticket/70
