### PR TITLE
Since we now forward the from_date variable to the view_meeting, the link has changed

### DIFF
--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -1040,7 +1040,7 @@ class Flasktests(Modeltests):
             self.assertTrue(
                 '<li class="message">Meeting added</li>' in output.data)
             self.assertTrue(
-                'href="/meeting/15/">' in output.data)
+                'href="/meeting/15/?from_date=' in output.data)
 
             # Calendar disabled
             data = {


### PR DESCRIPTION
This fixes the unit-tests
