### PR TITLE
The orange week in the month calendar reflects current week

### DIFF
--- a/fedocal/fedocallib/__init__.py
+++ b/fedocal/fedocallib/__init__.py
@@ -753,8 +753,7 @@ def get_html_monthly_cal(
     htmlcal = FedocalCalendar(day=day, year=year, month=month,
                               calendar_name=calendar_name,
                               loc_name=loc_name,
-                              busy_days=busy_days,
-                              cur_day=cur_date)
+                              busy_days=busy_days)
     curmonth_cal_nf = htmlcal.formatmonth()
 
     return curmonth_cal_nf

--- a/fedocal/fedocallib/fedora_calendar.py
+++ b/fedocal/fedocallib/fedora_calendar.py
@@ -27,8 +27,7 @@ class FedocalCalendar(HTMLCalendar):
     """
 
     def __init__(self, year, month, day,
-                 calendar_name=None, loc_name=None, busy_days=[],
-                 cur_day=None):
+                 calendar_name=None, loc_name=None, busy_days=[]):
         """ Constructor.
         Stores the year and the month asked.
         """
@@ -37,7 +36,6 @@ class FedocalCalendar(HTMLCalendar):
         self.month = month
         self.day = day
         self.busy_days = busy_days
-        self.cur_day = cur_day
         self.calendar_name = calendar_name
         self.loc_name = loc_name
 
@@ -167,10 +165,7 @@ class FedocalCalendar(HTMLCalendar):
         #item('\n')
         for week in self.monthdays2calendar(self.year, self.month):
             days = [day[0] for day in week]
-            if self.cur_day \
-                    and self.cur_day.day in days \
-                    and self.cur_day.month == self.month \
-                    and self.cur_day.year == self.year:
+            if self.day in days:
                 item(self.formatweek(week, current=True))
             else:
                 item(self.formatweek(week))

--- a/tests/test_fedora_calendar.py
+++ b/tests/test_fedora_calendar.py
@@ -89,59 +89,74 @@ class FedocalCalendartests(Modeltests):
     def test_formatmonth(self):
         """ Test the formatmonth function. """
         cal = FedocalCalendar(2012, 1, 10)
-        self.assertEqual(
-            cal.formatmonth(),
-            '<table class="month">\n<tr><th colspan="7" class="month"> '
-            'January 2012 </th></tr>\n<tr><td '
-            'class="noday">&nbsp;</td><td class="noday">&nbsp;'
-            '</td><td class="noday">&nbsp;</td><td class="noday">'
-            '&nbsp;</td><td class="noday">&nbsp;</td><td class="noday">'
-            '&nbsp;</td><td class="sun">1</td></tr>\n<tr><td '
-            'class="mon">2</td><td class="tue">3</td><td class="wed">'
-            '4</td><td class="thu">5</td><td class="fri">6</td><td '
-            'class="sat">7</td><td class="sun">8</td></tr>\n<tr><td '
-            'class="mon">9</td><td '
-            'class="tue">10</td><td class="wed">11</td><td '
-            'class="thu">12</td><td class="fri">13</td><td '
-            'class="sat">14</td><td class="sun">15</td></tr>\n<tr><td'
-            ' class="mon">16</td><td class="tue">17</td><td '
-            'class="wed">18</td><td class="thu">19</td><td '
-            'class="fri">20</td><td class="sat">21</td><td '
-            'class="sun">22</td></tr>\n<tr><td class="mon">23</td>'
-            '<td class="tue">24</td><td class="wed">25</td><td '
-            'class="thu">26</td><td class="fri">27</td><td '
-            'class="sat">28</td><td class="sun">29</td></tr>\n<tr>'
-            '<td class="mon">30</td><td class="tue">31</td><td '
-            'class="noday">&nbsp;</td><td class="noday">&nbsp;</td>'
-            '<td class="noday">&nbsp;</td><td class="noday">&nbsp;</td>'
-            '<td class="noday">&nbsp;</td></tr>\n</table>\n')
 
-        self.assertEqual(
-            cal.formatmonth(False),
-            '<table class="month">\n<tr><th colspan="7" class="month">'
-            ' January </th></tr>\n<tr><td '
-            'class="noday">&nbsp;</td><td class="noday">&nbsp;'
-            '</td><td class="noday">&nbsp;</td><td class="noday">'
-            '&nbsp;</td><td class="noday">&nbsp;</td><td class="noday">'
-            '&nbsp;</td><td class="sun">1</td></tr>\n<tr><td '
-            'class="mon">2</td><td class="tue">3</td><td class="wed">'
-            '4</td><td class="thu">5</td><td class="fri">6</td><td '
-            'class="sat">7</td><td class="sun">8</td></tr>\n<tr><td '
-            'class="mon">9</td><td '
-            'class="tue">10</td><td class="wed">11</td><td '
-            'class="thu">12</td><td class="fri">13</td><td '
-            'class="sat">14</td><td class="sun">15</td></tr>\n<tr><td'
-            ' class="mon">16</td><td class="tue">17</td><td '
-            'class="wed">18</td><td class="thu">19</td><td '
-            'class="fri">20</td><td class="sat">21</td><td '
-            'class="sun">22</td></tr>\n<tr><td class="mon">23</td>'
-            '<td class="tue">24</td><td class="wed">25</td><td '
-            'class="thu">26</td><td class="fri">27</td><td '
-            'class="sat">28</td><td class="sun">29</td></tr>\n<tr>'
-            '<td class="mon">30</td><td class="tue">31</td><td '
-            'class="noday">&nbsp;</td><td class="noday">&nbsp;</td>'
+        expcal = [
+            '<table class="month">',
+            '<tr><th colspan="7" class="month"> January 2012 </th></tr>',
+            '<tr><td class="noday">&nbsp;</td><td class="noday">&nbsp;</td>'
             '<td class="noday">&nbsp;</td><td class="noday">&nbsp;</td>'
-            '<td class="noday">&nbsp;</td></tr>\n</table>\n')
+            '<td class="noday">&nbsp;</td><td class="noday">&nbsp;</td>'
+            '<td class="sun">1</td></tr>',
+            '<tr><td class="mon">2</td><td class="tue">3</td>'
+            '<td class="wed">4</td><td class="thu">5</td>'
+            '<td class="fri">6</td><td class="sat">7</td>'
+            '<td class="sun">8</td></tr>',
+            '<tr class="current_week"><td class="mon">9</td>'
+            '<td class="tue">10</td><td class="wed">11</td>'
+            '<td class="thu">12</td><td class="fri">13</td>'
+            '<td class="sat">14</td><td class="sun">15</td></tr>',
+            '<tr><td class="mon">16</td><td class="tue">17</td>'
+            '<td class="wed">18</td><td class="thu">19</td>'
+            '<td class="fri">20</td><td class="sat">21</td>'
+            '<td class="sun">22</td></tr>',
+            '<tr><td class="mon">23</td><td class="tue">24</td>'
+            '<td class="wed">25</td><td class="thu">26</td>'
+            '<td class="fri">27</td><td class="sat">28</td>'
+            '<td class="sun">29</td></tr>',
+            '<tr><td class="mon">30</td><td class="tue">31</td>'
+            '<td class="noday">&nbsp;</td><td class="noday">&nbsp;</td>'
+            '<td class="noday">&nbsp;</td><td class="noday">&nbsp;</td>'
+            '<td class="noday">&nbsp;</td></tr>',
+            '</table>', '']
+        callines = cal.formatmonth().split('\n')
+
+        self.assertEqual(len(expcal), len(callines))
+        for cnt in range(0, len(callines)):
+            self.assertEqual(expcal[cnt], callines[cnt])
+
+        expcal = [
+            '<table class="month">',
+            '<tr><th colspan="7" class="month"> January </th></tr>',
+            '<tr><td class="noday">&nbsp;</td><td class="noday">&nbsp;</td>'
+            '<td class="noday">&nbsp;</td><td class="noday">&nbsp;</td>'
+            '<td class="noday">&nbsp;</td><td class="noday">&nbsp;</td>'
+            '<td class="sun">1</td></tr>',
+            '<tr><td class="mon">2</td><td class="tue">3</td>'
+            '<td class="wed">4</td><td class="thu">5</td>'
+            '<td class="fri">6</td><td class="sat">7</td>'
+            '<td class="sun">8</td></tr>',
+            '<tr class="current_week"><td class="mon">9</td>'
+            '<td class="tue">10</td><td class="wed">11</td>'
+            '<td class="thu">12</td><td class="fri">13</td>'
+            '<td class="sat">14</td><td class="sun">15</td></tr>',
+            '<tr><td class="mon">16</td><td class="tue">17</td>'
+            '<td class="wed">18</td><td class="thu">19</td>'
+            '<td class="fri">20</td><td class="sat">21</td>'
+            '<td class="sun">22</td></tr>',
+            '<tr><td class="mon">23</td><td class="tue">24</td>'
+            '<td class="wed">25</td><td class="thu">26</td>'
+            '<td class="fri">27</td><td class="sat">28</td>'
+            '<td class="sun">29</td></tr>',
+            '<tr><td class="mon">30</td><td class="tue">31</td>'
+            '<td class="noday">&nbsp;</td><td class="noday">&nbsp;</td>'
+            '<td class="noday">&nbsp;</td><td class="noday">&nbsp;</td>'
+            '<td class="noday">&nbsp;</td></tr>',
+            '</table>', '']
+        callines = cal.formatmonth(withyear=False).split('\n')
+
+        self.assertEqual(len(expcal), len(callines))
+        for cnt in range(0, len(callines)):
+            self.assertEqual(expcal[cnt], callines[cnt])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In the last release the orange week was changed to be the current week (in the real
calendar), this commit puts it back to be the week displayed in the calendar.

Adjust the unit-tests also so make them a little more easier to debug in the future

Fixes https://fedorahosted.org/fedocal/ticket/110
