### PR TITLE
Enforce the timezone name to be fedocal_<standar_name>

### DIFF
--- a/fedocal/__init__.py
+++ b/fedocal/__init__.py
@@ -523,8 +523,11 @@ def ical_out(calendar_name):
         datetime.datetime.utcnow().strftime('%Y-%m-%d %Hh%M'))
     )
     headers["Content-Disposition"] = "attachment; filename=%s" % filename
+    output = ical.serialize()
+    output = output.replace('TZID:', 'TZID:fedocal_')
+    output = output.replace('TZID=', 'TZID=fedocal_')
     return flask.Response(
-        ical.serialize(),
+        output,
         mimetype='text/calendar',
         headers=headers)
 


### PR DESCRIPTION
Apparently evolution and google calendar ignore the timezone specified at the top of the
file if they follow some sort of standard.
For example, if you set a meeting in the timezone 'US/Eastern' the timezone ID is EST and
evolution ignores the timezone decalaration at the top of the file to replace it by its own.
With this commits the timezone ID becomes fedocal_EST which google calendar and
evolution won't know and thus won't ignore.

This fixes https://fedorahosted.org/fedocal/ticket/112
