### PR TITLE
Fix displaying full day meetings

### DIFF
--- a/fedocal/fedocallib/__init__.py
+++ b/fedocal/fedocallib/__init__.py
@@ -283,7 +283,7 @@ def format_full_day_meeting(meeting_list, week_start):
         if idx.days < 0:
             # Skip meetings finishing exactly at 00:00 on the day the week
             # starts
-            if meeting.meeting_date_end == week_start + timedelta(days=7) \
+            if meeting.meeting_date_end == week_start \
                     and meeting.meeting_time_stop.hour == 0:
                 continue
             idx = idx + timedelta(days=abs(idx.days))


### PR DESCRIPTION
We were ignoring the meetings started the week before and ending the week
after at 00:00.
In fact what we want to ignore are meetings that starts the week before and
ending on the day the week starts at 00:00.

Fixes https://fedorahosted.org/fedocal/ticket/120
