### PR TITLE
Drop the weekly navigation keys on the list view

### DIFF
--- a/fedocal/templates/default/meeting_list.html
+++ b/fedocal/templates/default/meeting_list.html
@@ -25,8 +25,10 @@
     </header>
     <nav id="weeks">
       <p>
+        {% if meetings %}
         {{ meetings[0].meeting_date.strftime('%d %b %Y') }} to
         {{ meetings[-1].meeting_date_end.strftime('%d %b %Y')  }}
+        {% endif %}
       </p>
     </nav>
 {% else %}


### PR DESCRIPTION
But instead indicate the start and end dates of the meetings displayed
