### PR TITLE
Fix meetings overlap

### DIFF
--- a/fedocal/static/default/fedocal.css
+++ b/fedocal/static/default/fedocal.css
@@ -173,10 +173,13 @@ td .last_event {
 
 #agenda td {
     min-width: 100px;
-    height: 2em;
     border: 1px solid #e6e6e6;
     background-color: #f9f9f9;
     padding: 0;
+}
+
+#agenda td > .row_height {
+    min-height: 2em;
 }
 
 #agenda td.empty {

--- a/fedocal/templates/default/agenda.html
+++ b/fedocal/templates/default/agenda.html
@@ -247,6 +247,8 @@ else %}{{ location }}{% endif %}{% endblock %}
               {% endif %}
               </a>
           {% endfor %}
+      {% else %}
+          <div class="row_height"></div>
       {% endif %}
       </td>
     {%- endmacro %}
@@ -280,7 +282,9 @@ else %}{{ location }}{% endif %}{% endblock %}
           <tr></tr>
           <tr>
               <th class="time" rowspan="2">00h00</th>
-              <td colspan="7" class="empty"></td>
+              <td colspan="7" class="empty">
+                  <div class="row_height"></div>
+              </td>
           </tr>
           {% set keys = meetings.keys()|sort %}
 


### PR DESCRIPTION
Actually, we got this:
![chevauchement](https://cloud.githubusercontent.com/assets/224733/4517994/10f70f56-4c6a-11e4-9b34-bcbfa654c202.png)

Simply removing td elements fixed height fixes the issue. I first try to use min-hegiht instead of height on those elements, but min-height is not supported on table elements.
The solution is here to create a div into empty tds, and apply a min-height to those new elements. I'm not fan of empty elements in the HTML, but I really do not found any other working solution.
