### PR TITLE
Fix error handling bug

### DIFF
--- a/fedocal/mail_logging.py
+++ b/fedocal/mail_logging.py
@@ -73,9 +73,9 @@ class ContextInjector(logging.Filter):
         record.pid = '-'
         if not isinstance(current_process, str):
             record.pid = current_process.pid
-        record.proc_name = current_process.name
-        record.command_line = " ".join(current_process.cmdline)
-        record.callstack = self.format_callstack()
+            record.proc_name = current_process.name
+            record.command_line = " ".join(current_process.cmdline)
+            record.callstack = self.format_callstack()
         return True
 
     @staticmethod


### PR DESCRIPTION
If current_process is a string it of course doesn't have the other stuff.
