### PR TITLE
Allow exporting iCal file for a calendar meeting.

### DIFF
--- a/fedocal/__init__.py
+++ b/fedocal/__init__.py
@@ -611,6 +611,33 @@ def ical_out(calendar_name):
         headers=headers)
 
 
+@APP.route('/ical/calendar/meeting/<int:meeting_id>/')
+def ical_calendar_meeting(meeting_id):
+    """ Returns a iCal feed of a calendar event.
+
+    :arg calendar_name: the name of the calendar for which one would
+        like to get the iCal feed.
+    """
+    meeting = Meeting.by_id(SESSION, meeting_id)
+    if not meeting:
+        return flask.abort(404)
+    ical = vobject.iCalendar()
+    fedocallib.add_meeting_to_vcal(ical, meeting)
+    headers = {}
+    filename = secure_filename('%s-%s-%s.ical' % (
+        meeting.calendar_name, meeting.meeting_name,
+        datetime.datetime.utcnow().strftime('%Y-%m-%d %Hh%M'))
+    )
+    headers["Content-Disposition"] = "attachment; filename=%s" % filename
+    output = ical.serialize()
+    output = output.replace('TZID:', 'TZID:fedocal_')
+    output = output.replace('TZID=', 'TZID=fedocal_')
+    return flask.Response(
+        output,
+        mimetype='text/calendar',
+        headers=headers)
+
+
 # CLA + 1
 @APP.route('/mine/')
 @cla_plus_one_required

--- a/fedocal/templates/default/view_meeting.html
+++ b/fedocal/templates/default/view_meeting.html
@@ -54,6 +54,11 @@
     {% endmacro %}
     <p>{{ _('Meeting organized by %(managers)s', managers=get_managers(meeting.meeting_manager)) }}</p>
 
+    <a href="{{ url_for('ical_calendar_meeting', meeting_id=meeting.meeting_id) }}"
+       title="{{ _('Add this meeting to your agenda') }}">
+       iCal export
+    </a>
+
     {% if editor %}
     <p>{{ _('Stored as:') }}</p>
     <ul>


### PR DESCRIPTION
This adds an ``iCal export`` link in calendar meeting page/snippet. This link allows to download iCal file for a single calendar meeting.