### PR TITLE
Enhance iCal file exports

### DIFF
--- a/fedocal.cfg.sample
+++ b/fedocal.cfg.sample
@@ -62,8 +62,8 @@ APP_URL = 'https://apps.fedoraproject.org/calendar/'
 
 ### Options for iCal remind before dropdown
 ICAL_REMINDER_AT_OPTIONS = (
-    ('-5m', '5 minutes'),
-    ('-1h', '1 hour'),
-    ('-1d', '1 day')
+    ('5', '5 minutes'),
+    ('60', '1 hour'),
+    ('1440', '1 day')
 )
 

--- a/fedocal.cfg.sample
+++ b/fedocal.cfg.sample
@@ -60,5 +60,10 @@ APP_URL = 'https://apps.fedoraproject.org/calendar/'
 ### problem. The email is sent to the address listed here.
 # EMAIL_ERROR = 'pingou@pingoured.fr'
 
-ICAL_REMINDERS = [{'days': -1}, {'hours': -1}, {'minutes': -5}]
+### Options for iCal remind before dropdown
+ICAL_REMINDER_AT_OPTIONS = (
+    ('-5m', '5 minutes'),
+    ('-1h', '1 hour'),
+    ('-1d', '1 day')
+)
 

--- a/fedocal.cfg.sample
+++ b/fedocal.cfg.sample
@@ -61,7 +61,7 @@ APP_URL = 'https://apps.fedoraproject.org/calendar/'
 # EMAIL_ERROR = 'pingou@pingoured.fr'
 
 ### Options for iCal remind before dropdown
-ICAL_REMINDER_AT_OPTIONS = (
+ICAL_REMINDER_OPTIONS = (
     ('5', '5 minutes'),
     ('60', '1 hour'),
     ('1440', '1 day')

--- a/fedocal.cfg.sample
+++ b/fedocal.cfg.sample
@@ -59,3 +59,6 @@ APP_URL = 'https://apps.fedoraproject.org/calendar/'
 ### In case of exception flask sends an email with some information to debug the
 ### problem. The email is sent to the address listed here.
 # EMAIL_ERROR = 'pingou@pingoured.fr'
+
+ICAL_REMINDERS = [{'days': -1}, {'hours': -1}, {'minutes': -5}]
+

--- a/fedocal/__init__.py
+++ b/fedocal/__init__.py
@@ -1039,7 +1039,7 @@ def view_meeting_page(meeting_id, full):
         title=meeting.meeting_name,
         editor=editor,
         from_date=from_date,
-        reminder_at_options=APP.config.get('ICAL_REMINDER_AT_OPTIONS') or []
+        reminder_options=APP.config.get('ICAL_REMINDER_OPTIONS', [])
     )
 
 

--- a/fedocal/__init__.py
+++ b/fedocal/__init__.py
@@ -622,7 +622,11 @@ def ical_calendar_meeting(meeting_id):
         return flask.abort(404)
     ical = vobject.iCalendar()
     fedocallib.add_meeting_to_vcal(
-        ical, meeting, enable_reminder=flask.request.args.get('reminder')=='1')
+        ical, meeting,
+        enable_reminder=flask.request.args.get('reminder') == '1',
+        reminders=APP.config.get('ICAL_REMINDERS') or [
+            {'days': -1}, {'hours': -1}, {'minutes': -5}
+        ])
     headers = {}
     filename = secure_filename('%s-%s-%s.ical' % (
         meeting.calendar_name, meeting.meeting_name,

--- a/fedocal/__init__.py
+++ b/fedocal/__init__.py
@@ -621,7 +621,8 @@ def ical_calendar_meeting(meeting_id):
     if not meeting:
         return flask.abort(404)
     ical = vobject.iCalendar()
-    fedocallib.add_meeting_to_vcal(ical, meeting, enable_reminder=True)
+    fedocallib.add_meeting_to_vcal(
+        ical, meeting, enable_reminder=flask.request.args.get('reminder')=='1')
     headers = {}
     filename = secure_filename('%s-%s-%s.ical' % (
         meeting.calendar_name, meeting.meeting_name,

--- a/fedocal/__init__.py
+++ b/fedocal/__init__.py
@@ -621,7 +621,7 @@ def ical_calendar_meeting(meeting_id):
     if not meeting:
         return flask.abort(404)
     ical = vobject.iCalendar()
-    fedocallib.add_meeting_to_vcal(ical, meeting)
+    fedocallib.add_meeting_to_vcal(ical, meeting, enable_reminder=True)
     headers = {}
     filename = secure_filename('%s-%s-%s.ical' % (
         meeting.calendar_name, meeting.meeting_name,

--- a/fedocal/default_config.py
+++ b/fedocal/default_config.py
@@ -73,7 +73,7 @@ LANGUAGES = {
 
 # Options for iCal remind before dropdown
 ICAL_REMINDER_AT_OPTIONS = (
-    ('-5m', '5 minutes'),
-    ('-1h', '1 hour'),
-    ('-1d', '1 day')
+    ('5', '5 minutes'),
+    ('60', '1 hour'),
+    ('1440', '1 day')
 )

--- a/fedocal/default_config.py
+++ b/fedocal/default_config.py
@@ -70,3 +70,10 @@ LANGUAGES = {
     'en': 'English',
     'fr': 'Français'
 }
+
+# Options for iCal remind before dropdown
+ICAL_REMINDER_AT_OPTIONS = (
+    ('-5m', '5 minutes'),
+    ('-1h', '1 hour'),
+    ('-1d', '1 day')
+)

--- a/fedocal/default_config.py
+++ b/fedocal/default_config.py
@@ -72,8 +72,9 @@ LANGUAGES = {
 }
 
 # Options for iCal remind before dropdown
-ICAL_REMINDER_AT_OPTIONS = (
+ICAL_REMINDER_OPTIONS = (
     ('5', '5 minutes'),
     ('60', '1 hour'),
     ('1440', '1 day')
 )
+

--- a/fedocal/fedocallib/__init__.py
+++ b/fedocal/fedocallib/__init__.py
@@ -666,7 +666,7 @@ def retrieve_meeting_to_remind(session, offset=30):
     return meetings
 
 
-def add_meeting_to_vcal(ical, meeting, enable_reminder=False):
+def add_meeting_to_vcal(ical, meeting, enable_reminder=False, reminders=[]):
     """ Convert a Meeting object into iCal object and add it to the
     provided calendar.
 
@@ -676,6 +676,8 @@ def add_meeting_to_vcal(ical, meeting, enable_reminder=False):
         iCal and add to the provided calendar.
     :kwarg enable_reminder: a boolean telling whether to add reminder
         for the meeting in the iCal object or not.
+    :kwarg reminders: a list of dictionaries, kwargs for instantiating
+        timedelta instances.
     """
     entry = ical.add('vevent')
     entry.add('summary').value = meeting.meeting_name
@@ -716,17 +718,8 @@ def add_meeting_to_vcal(ical, meeting, enable_reminder=False):
         entry.rruleset = newrule
 
     if enable_reminder:
-        # FIXME: This timedeltas could be part of conf or explicitly
-        #        mentioned by the caller. A policy decision to make.
-
-        # FIXME: I am adding multiple VALARM elements here because docs at
-        #        http://www.kanzaki.com/docs/ical/valarm.html do
-        #        say nothing about having multiple TRIGGERS inside a VALARM.
-        #        Also, REPEAT does not seem much useful as we are not reminding
-        #        regular intervals.
         for trigger in (
-                timedelta(days=-1), timedelta(hours=-1),
-                timedelta(minutes=-5)):
+                timedelta(**reminder) for reminder in reminders):
             valarm = entry.add('valarm')
             valarm.add('trigger').value = trigger
             valarm.add('action').value = 'DISPLAY'

--- a/fedocal/fedocallib/__init__.py
+++ b/fedocal/fedocallib/__init__.py
@@ -666,7 +666,7 @@ def retrieve_meeting_to_remind(session, offset=30):
     return meetings
 
 
-def add_meeting_to_vcal(ical, meeting, enable_reminder=False, reminders=[]):
+def add_meeting_to_vcal(ical, meeting, reminder=None):
     """ Convert a Meeting object into iCal object and add it to the
     provided calendar.
 
@@ -674,10 +674,7 @@ def add_meeting_to_vcal(ical, meeting, enable_reminder=False, reminders=[]):
         be added.
     :arg meeting: a single fedocal.model.Meeting object to convert to
         iCal and add to the provided calendar.
-    :kwarg enable_reminder: a boolean telling whether to add reminder
-        for the meeting in the iCal object or not.
-    :kwarg reminders: a list of dictionaries, kwargs for instantiating
-        timedelta instances.
+    :kwarg reminder: None or a datetime.timedelta instance.
     """
     entry = ical.add('vevent')
     entry.add('summary').value = meeting.meeting_name
@@ -717,19 +714,17 @@ def add_meeting_to_vcal(ical, meeting, enable_reminder=False, reminders=[]):
                 until=meeting.recursion_ends))
         entry.rruleset = newrule
 
-    if enable_reminder:
-        for trigger in (
-                timedelta(**reminder) for reminder in reminders):
-            valarm = entry.add('valarm')
-            valarm.add('trigger').value = trigger
-            valarm.add('action').value = 'DISPLAY'
-            valarm.add('description').value = (
-                '[{calendar_name}] [Fedocal] Reminder meeting: {meeting_name}'
-            ).format(calendar_name=meeting.calendar_name,
-                     meeting_name=meeting.meeting_name)
+    if reminder:
+        valarm = entry.add('valarm')
+        valarm.add('trigger').value = reminder
+        valarm.add('action').value = 'DISPLAY'
+        valarm.add('description').value = (
+            '[{calendar_name}] [Fedocal] Reminder meeting: {meeting_name}'
+        ).format(calendar_name=meeting.calendar_name,
+                 meeting_name=meeting.meeting_name)
 
 
-def add_meetings_to_vcal(ical, meetings, enable_reminder=False):
+def add_meetings_to_vcal(ical, meetings, reminder=None):
     """ Convert the Meeting objects into iCal object and add them to
     the provided calendar.
 
@@ -737,11 +732,10 @@ def add_meetings_to_vcal(ical, meetings, enable_reminder=False):
         be added.
     :arg meetings: a list of fedocal.model.Meeting object to convert to
         iCal and add to the provided calendar.
-    :kwarg enable_reminder: a boolean telling whether to add reminder
-        for the meetings in the iCal object or not.
+    :kwarg reminder: None or a datetime.timedelta instance.
     """
     for meeting in meetings:
-        add_meeting_to_vcal(ical, meeting)
+        add_meeting_to_vcal(ical, meeting, reminder)
 
 
 def get_html_monthly_cal(

--- a/fedocal/templates/default/view_meeting.html
+++ b/fedocal/templates/default/view_meeting.html
@@ -54,9 +54,11 @@
     {% endmacro %}
     <p>{{ _('Meeting organized by %(managers)s', managers=get_managers(meeting.meeting_manager)) }}</p>
 
-    <a id="ical-meeting-export" href="{{ url_for('ical_calendar_meeting', meeting_id=meeting.meeting_id) }}"
-       title="{{ _('Add this meeting to your agenda') }}">
-       {{ _('iCal export') }}
+    <a href="{{ url_for('ical_calendar_meeting',
+        meeting_id=meeting.meeting_id) }}"
+        id="ical-meeting-export"
+        title="{{ _('Add this meeting to your agenda') }}">
+        {{ _('iCal export') }}
     </a>
     {% if reminder_options %}
     <span>

--- a/fedocal/templates/default/view_meeting.html
+++ b/fedocal/templates/default/view_meeting.html
@@ -160,7 +160,7 @@
             if (this.checked) {
                 $icalReminderOptions.removeAttr('disabled');
                 $icalExportLink.attr(
-                    'href', $icalExportLink.attr('href') + '?reminder_at=' +
+                    'href', $icalExportLink.attr('href') + '?reminder_delta=' +
                     $icalReminderOptions.val());
             } else {
                $icalReminderOptions.attr('disabled', 'disabled');
@@ -176,7 +176,7 @@
             $icalExportLink.attr(
                 'href',
                 $icalExportLink.attr('href').split('?')[0] +
-                '?reminder_at=' + $this.val());
+                '?reminder_delta=' + $this.val());
         });
     });
     </script>

--- a/fedocal/templates/default/view_meeting.html
+++ b/fedocal/templates/default/view_meeting.html
@@ -54,10 +54,16 @@
     {% endmacro %}
     <p>{{ _('Meeting organized by %(managers)s', managers=get_managers(meeting.meeting_manager)) }}</p>
 
-    <a href="{{ url_for('ical_calendar_meeting', meeting_id=meeting.meeting_id) }}"
+    <a id="ical-meeting-export" href="{{ url_for('ical_calendar_meeting', meeting_id=meeting.meeting_id) }}"
        title="{{ _('Add this meeting to your agenda') }}">
        {{ _('iCal export') }}
     </a>
+    <span>
+        <label for="ical-meeting-export-reminder-toggle">
+            <input id="ical-meeting-export-reminder-toggle" type="checkbox">
+            <em>{{ _('with reminder') }}</em>
+        </label>
+    </span>
 
     {% if editor %}
     <p>{{ _('Stored as:') }}</p>
@@ -138,6 +144,17 @@
             } else {
                 $(this).html('{{ _('Meeting is over!')|e }}');
             }
+        });
+
+        // Handle iCal meeting export with reminder toggle
+        $('#ical-meeting-export-reminder-toggle').change(function (e) {
+            var $icalExportLink = $('#ical-meeting-export');
+            if (this.checked)
+                $icalExportLink.attr(
+                    'href', $icalExportLink.attr('href') + '?reminder=1');
+            else
+                $icalExportLink.attr(
+                    'href', $icalExportLink.attr('href').split('?')[0]);
         });
     });
     </script>

--- a/fedocal/templates/default/view_meeting.html
+++ b/fedocal/templates/default/view_meeting.html
@@ -61,8 +61,15 @@
     <span>
         <label for="ical-meeting-export-reminder-toggle">
             <input id="ical-meeting-export-reminder-toggle" type="checkbox">
-            <em>{{ _('with reminder') }}</em>
+            <em>{{ _('with reminder before') }}</em>
         </label>
+        <select id="ical-meeting-export-reminder-at" disabled="disabled">
+            {% for option in reminder_at_options %}
+                <option value="{{ option[0] }}"{% if loop.index == 0 %} selected="selected"{% endif %}>
+                    {{ option[1] }}
+                </option>
+            {% endfor %}
+        </select>
     </span>
 
     {% if editor %}
@@ -149,12 +156,27 @@
         // Handle iCal meeting export with reminder toggle
         $('#ical-meeting-export-reminder-toggle').change(function (e) {
             var $icalExportLink = $('#ical-meeting-export');
-            if (this.checked)
+            var $icalReminderOptions = $('#ical-meeting-export-reminder-at');
+            if (this.checked) {
+                $icalReminderOptions.removeAttr('disabled');
                 $icalExportLink.attr(
-                    'href', $icalExportLink.attr('href') + '?reminder=1');
-            else
-                $icalExportLink.attr(
+                    'href', $icalExportLink.attr('href') + '?reminder_at=' +
+                    $icalReminderOptions.val());
+            } else {
+               $icalReminderOptions.attr('disabled', 'disabled');
+               $icalExportLink.attr(
                     'href', $icalExportLink.attr('href').split('?')[0]);
+            }
+        });
+
+        // Handle change event in reminder options dropdown in iCal export
+        $('#ical-meeting-export-reminder-at').change(function (e) {
+            var $this = $(this);
+            var $icalExportLink = $('#ical-meeting-export');
+            $icalExportLink.attr(
+                'href',
+                $icalExportLink.attr('href').split('?')[0] +
+                '?reminder_at=' + $this.val());
         });
     });
     </script>

--- a/fedocal/templates/default/view_meeting.html
+++ b/fedocal/templates/default/view_meeting.html
@@ -58,19 +58,21 @@
        title="{{ _('Add this meeting to your agenda') }}">
        {{ _('iCal export') }}
     </a>
+    {% if reminder_options %}
     <span>
         <label for="ical-meeting-export-reminder-toggle">
             <input id="ical-meeting-export-reminder-toggle" type="checkbox">
             <em>{{ _('with reminder before') }}</em>
         </label>
         <select id="ical-meeting-export-reminder-at" disabled="disabled">
-            {% for option in reminder_at_options %}
+            {% for option in reminder_options %}
                 <option value="{{ option[0] }}"{% if loop.index == 0 %} selected="selected"{% endif %}>
                     {{ option[1] }}
                 </option>
             {% endfor %}
         </select>
     </span>
+    {% endif %}
 
     {% if editor %}
     <p>{{ _('Stored as:') }}</p>

--- a/fedocal/templates/default/view_meeting.html
+++ b/fedocal/templates/default/view_meeting.html
@@ -154,7 +154,7 @@
         });
 
         // Handle iCal meeting export with reminder toggle
-        $('#ical-meeting-export-reminder-toggle').change(function (e) {
+        $('#ical-meeting-export-reminder-toggle').on('change', function (e) {
             var $icalExportLink = $('#ical-meeting-export');
             var $icalReminderOptions = $('#ical-meeting-export-reminder-at');
             if (this.checked) {
@@ -170,7 +170,7 @@
         });
 
         // Handle change event in reminder options dropdown in iCal export
-        $('#ical-meeting-export-reminder-at').change(function (e) {
+        $('#ical-meeting-export-reminder-at').on('change', function (e) {
             var $this = $(this);
             var $icalExportLink = $('#ical-meeting-export');
             $icalExportLink.attr(

--- a/tests/sample_files/meeting_with_reminder.ical
+++ b/tests/sample_files/meeting_with_reminder.ical
@@ -1,0 +1,17 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//PYVOBJECT//NONSGML Version 1//EN
+BEGIN:VEVENT
+UID:DUMMY_UID
+DTSTART:{start_datetime}
+DTEND:{end_datetime}
+DESCRIPTION:This is another test meeting
+ORGANIZER:pingou
+SUMMARY:test-meeting2
+BEGIN:VALARM
+ACTION:DISPLAY
+DESCRIPTION:[test_calendar] [Fedocal] Reminder meeting: test-meeting2
+TRIGGER:-PT1H
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -454,6 +454,18 @@ class Flasktests(Modeltests):
         )
         self.assertEqual(data, expected_data)
 
+        # Test non numeric value for numeric data
+        output = self.app.get('/ical/calendar/meeting/2/?reminder_delta=foo')
+        self.assertEqual(output.status_code, 200)
+        self.assertFalse('VALARM' in output.data)
+        self.assertEqual(data, expected_data)
+
+        # Test with a reminder_delta value not in the default choice
+        output = self.app.get('/ical/calendar/meeting/2/?reminder_delta=150')
+        self.assertEqual(output.status_code, 200)
+        self.assertTrue('VALARM' in output.data)
+        self.assertTrue('TRIGGER:-PT2H30M' in output.data)
+
     def test_view_meeting(self):
         """ Test the view_meeting function. """
         self.__setup_db()


### PR DESCRIPTION
This branch improves export of iCal files in the following ways:
- Allow export iCal file for a calendar event
- Add reminder logic in iCal file
- when downloading iCal info for a meeting, allow the option to add a reminder as well.

``NOTE``: This is work in progress and the PR has been created for review of ongoing work.