### PR TITLE
Rather than disabling, hide the timezone field for full-day meeting

### DIFF
--- a/fedocal/templates/default/add_meeting.html
+++ b/fedocal/templates/default/add_meeting.html
@@ -208,7 +208,6 @@
 
       var cb = $('#full_day')
       var tz = $('#meeting_timezone').parent().parent();
-      console.log(tz);
       if(cb.prop('checked')) {
         tz.val('UTC');
         tz.hide();

--- a/fedocal/templates/default/add_meeting.html
+++ b/fedocal/templates/default/add_meeting.html
@@ -207,22 +207,20 @@
       });
 
       var cb = $('#full_day')
-      var tz = $('#meeting_timezone');
-      if(cb.checked) {
+      var tz = $('#meeting_timezone').parent().parent();
+      console.log(tz);
+      if(cb.prop('checked')) {
         tz.val('UTC');
-        tz.attr('disabled', true);
-        tz.addClass('ui-state-disabled');
+        tz.hide();
       };
 
       $('#full_day').click(function() {
-        var tz = $('#meeting_timezone');
+        var tz = $('#meeting_timezone').parent().parent();
         if(this.checked == false) {
-            tz.removeAttr('disabled');
-            tz.removeClass('ui-state-disabled');
+          tz.show();
         } else {
-            tz.val('UTC');
-            tz.attr('disabled', true);
-            tz.addClass('ui-state-disabled');
+          tz.val('UTC');
+          tz.hide();
         };
       });
     });

--- a/fedocal/templates/default/edit_meeting.html
+++ b/fedocal/templates/default/edit_meeting.html
@@ -213,22 +213,19 @@
     });
 
     var cb = $('#full_day')
-    var tz = $('#meeting_timezone');
-    if(cb.checked) {
+    var tz = $('#meeting_timezone').parent().parent();
+    if(cb.prop('checked')) {
       tz.val('UTC');
-      tz.attr('disabled', true);
-      tz.addClass('ui-state-disabled');
+      tz.hide();
     };
 
     $('#full_day').click(function() {
-      var tz = $('#meeting_timezone');
+      var tz = $('#meeting_timezone').parent().parent();
       if(this.checked == false) {
-          tz.removeAttr('disabled');
-          tz.removeClass('ui-state-disabled');
+        tz.show();
       } else {
-          tz.val('UTC');
-          tz.attr('disabled', true);
-          tz.addClass('ui-state-disabled');
+        tz.val('UTC');
+        tz.hide();
       };
     });
   });


### PR DESCRIPTION
Full-day meetings are hard-coded to be from D 00:00 to D+X 00:00 UTC.
Until now we used to disable the timezone field, which meant it was not
sent when the form was submitting, leading to an 'invalid choice' error.
Now, we just set it to UTC and hide it.
This way it is sent as part of the form but it is not shown in the UI
which is what we want since the user cannot change the TZ for full-day
meetings.

Fixes https://fedorahosted.org/fedocal/ticket/150