### PR TITLE
Place the fedmenu on the left side to not overlap with the button on the agenda

### DIFF
--- a/fedocal/templates/default/master.html
+++ b/fedocal/templates/default/master.html
@@ -121,7 +121,7 @@
       fedmenu({
           'url': '{{ config["FEDMENU_DATA_URL"] }}',
           'mimeType': 'application/javascript',
-          'position': 'bottom-right',
+          'position': 'bottom-left',
       });
     </script>
     {% endif %}


### PR DESCRIPTION
This fixes the overlap between the buttons on the agenda view, cf:
https://apps.stg.fedoraproject.org/calendar/irc%40fedora-meeting/