### PR TITLE
Specify rel="noopener noreferrer" to link including target='_blank'

### DIFF
--- a/fedocal/templates/centos/master.html
+++ b/fedocal/templates/centos/master.html
@@ -77,7 +77,7 @@
           Copyright &copy; 2012-2014 Red Hat
           <a href="https://fedorahosted.org/fedocal/">fedocal</a>
           -- {{version}}
-          -- <a href="http://fedocal.rtfd.org"
+          -- <a href="http://fedocal.rtfd.org" rel="noopener noreferrer"
               target="_blank">{{ _('Documentation') }}</a>
           -- <a href="http://fedocal.readthedocs.org/en/latest/contributors.html">{{ _('Authors') }}</a>
           -- <a href="{{ url_for('api') }}">{{ _('API') }}</a>

--- a/fedocal/templates/default/add_meeting.html
+++ b/fedocal/templates/default/add_meeting.html
@@ -30,7 +30,7 @@
             {{ render_field_in_row(form.meeting_timezone) }}
             {% macro get_after_markdown() %}
                 {{_('Supports the') }} <a href="http://daringfireball.net/projects/markdown/syntax"
-                    target="_blank">{{ _('Markdown syntax') }}</a>
+                    rel="noopener noreferrer" target="_blank">{{ _('Markdown syntax') }}</a>
                 <input type="button" class="event preview" value="{{ _('Preview')  }}">
             {% endmacro %}
             {{ render_field_in_row(

--- a/fedocal/templates/default/edit_meeting.html
+++ b/fedocal/templates/default/edit_meeting.html
@@ -25,7 +25,7 @@
             {{ render_field_in_row(form.comanager) }}
             {% macro get_after_markdown() %}
                 {{_('Supports the') }} <a href="http://daringfireball.net/projects/markdown/syntax"
-                    target="_blank">{{ _('Markdown syntax') }}</a>
+                    rel="noopener noreferrer" target="_blank">{{ _('Markdown syntax') }}</a>
                 <input type="button" class="event preview" value="{{ _('Preview')  }}">
             {% endmacro %}
             {{ render_field_in_row(

--- a/fedocal/templates/default/master.html
+++ b/fedocal/templates/default/master.html
@@ -77,7 +77,7 @@
           Copyright &copy; 2012-2015 Red Hat
           <a href="https://fedorahosted.org/fedocal/">fedocal</a>
           -- {{version}}
-          -- <a href="http://fedocal.rtfd.org"
+          -- <a href="http://fedocal.rtfd.org" rel="noopener noreferrer"
               target="_blank">{{ _('Documentation') }}</a>
           -- <a href="http://fedocal.readthedocs.org/en/latest/contributors.html">{{ _('Authors') }}</a>
           -- <a href="{{ url_for('api') }}">{{ _('API') }}</a>


### PR DESCRIPTION
This avoids potential security risk:
https://dev.to/ben/the-targetblank-vulnerability-by-example
https://mathiasbynens.github.io/rel-noopener/