### PR TITLE
Drop the `meeting` variable and adjust `next_meeting` to the timezone

### DIFF
--- a/fedocal/__init__.py
+++ b/fedocal/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
- (c) 2012-2015 - Copyright Pierre-Yves Chibon <pingou@pingoured.fr>
+ (c) 2012-2016 - Copyright Pierre-Yves Chibon <pingou@pingoured.fr>
 
  Distributed under License GPLv3 or later
  You can find a copy of this license on the website
@@ -1077,15 +1077,12 @@ def view_meeting_page(meeting_id, full):
             'errors')
         return flask.redirect(flask.url_for('index'))
 
-    meeting = fedocallib.convert_meeting_timezone(
-        meeting, meeting.meeting_timezone, tzone)
-
     meeting_utc = fedocallib.convert_meeting_timezone(
         org_meeting, org_meeting.meeting_timezone, 'UTC')
 
     editor = False
-    if is_meeting_manager(meeting) or is_calendar_admin(
-            meeting.calendar):
+    if is_meeting_manager(org_meeting) or is_calendar_admin(
+            org_meeting.calendar):
         editor = True
 
     date_limit = None
@@ -1097,11 +1094,12 @@ def view_meeting_page(meeting_id, full):
 
     next_meeting = fedocallib.update_date_rec_meeting(
         meeting_utc, action='next', date_limit=date_limit)
+    next_meeting = fedocallib.convert_meeting_timezone(
+        next_meeting, next_meeting.meeting_timezone, tzone)
 
     return flask.render_template(
         'view_meeting.html',
         full=full,
-        meeting=meeting,
         meeting_utc=meeting_utc,
         next_meeting=next_meeting,
         org_meeting=org_meeting,

--- a/fedocal/templates/default/view_meeting.html
+++ b/fedocal/templates/default/view_meeting.html
@@ -1,7 +1,7 @@
 {% if full %}
 {% extends "master.html" %}
 
-{% block title %}{{ _('Meeting "%(name)s"', name=meeting.meeting_name) }}{% endblock %}
+{% block title %}{{ _('Meeting "%(name)s"', name=org_meeting.meeting_name) }}{% endblock %}
 
 {%block tag %}home{% endblock %}
 
@@ -11,14 +11,14 @@
 
 {% block content %}
 <section>
-        <h2 class="orange">{{ _('Meeting "%(name)s"', name=meeting.meeting_name) }}</h2>
-        <p class="blue">(<a href="{{ url_for('calendar', calendar_name=meeting.calendar_name) }}">
-            {{ meeting.calendar_name }}</a>)
+        <h2 class="orange">{{ _('Meeting "%(name)s"', name=org_meeting.meeting_name) }}</h2>
+        <p class="blue">(<a href="{{ url_for('calendar', calendar_name=org_meeting.calendar_name) }}">
+            {{ org_meeting.calendar_name }}</a>)
         </p>
 
 
-    {% if meeting.meeting_location %}
-    <p>{{ _('Location:') }} {{ meeting.meeting_location }}</p>
+    {% if org_meeting.meeting_location %}
+    <p>{{ _('Location:') }} {{ org_meeting.meeting_location }}</p>
     {%endif%}
 
     <ul>
@@ -28,7 +28,7 @@
               {{ _('Start:') }}
           </span>
           {{ next_meeting.meeting_date.strftime('%a, %B %d, %Y') }} - {{
-            meeting.meeting_time_start.strftime('%H:%M') }} {{ tzone }}
+            next_meeting.meeting_time_start.strftime('%H:%M') }} {{ tzone }}
         </li>
         <li title="{{ meeting_utc.meeting_date_end.strftime('%a, %B %d, %Y') }} - {{
             meeting_utc.meeting_time_stop }} UTC">
@@ -36,17 +36,18 @@
               {{ _('End:') }}
           </span>
           {{ next_meeting.meeting_date_end.strftime('%a, %B %d, %Y') }} - {{
-              meeting.meeting_time_stop }} {{ tzone }} </li>
+              next_meeting.meeting_time_stop }} {{ tzone }} </li>
     </ul>
 
     <div id="countdown"></div>
 
     <div id="meeting_description">
-    {% autoescape off%} {{ meeting.meeting_information | markdown  or _('No description') }} {% endautoescape %}
+    {% autoescape off%} {{ org_meeting.meeting_information | markdown  or _('No description') }} {% endautoescape %}
     </div>
 
-    {% if meeting.recursion_frequency and meeting.recursion_ends %}
-    <p>{{ _('This meeting is recurrent, it occurs every %(frequency)s days until %(ends)s', frequency=meeting.recursion_frequency, ends=meeting.recursion_ends) }}
+    {% if org_meeting.recursion_frequency and org_meeting.recursion_ends %}
+    <p>{{ _('This meeting is recurrent, it occurs every %(frequency)s days until %(ends)s',
+            frequency=org_meeting.recursion_frequency, ends=org_meeting.recursion_ends) }}
     </p>
     {% endif %}
 
@@ -54,10 +55,10 @@
         {% for manager in managers %}<a href="mailto:{{manager}}@fedoraproject.org">{{ manager }}</a>
         {%- if not loop.last %},{% endif %}{% endfor %}.
     {% endmacro %}
-    <p>{{ _('Meeting organized by %(managers)s', managers=get_managers(meeting.meeting_manager)) }}</p>
+    <p>{{ _('Meeting organized by %(managers)s', managers=get_managers(org_meeting.meeting_manager)) }}</p>
 
     <a href="{{ url_for('ical_calendar_meeting',
-        meeting_id=meeting.meeting_id) }}"
+        meeting_id=org_meeting.meeting_id) }}"
         id="ical-meeting-export"
         title="{{ _('Add this meeting to your agenda') }}">
         {{ _('iCal export') }}
@@ -98,12 +99,12 @@
     </ul>
     <p>
         <a href="{{ url_for('edit_meeting',
-            meeting_id=meeting.meeting_id, from_date=from_date) }}">
+            meeting_id=org_meeting.meeting_id, from_date=from_date) }}">
             <img src="{{ url_for('static', filename='edit.png') }}"
                 title="{{ _('Edit') }}" alt="{{ _('Edit') }}"/>
         </a>
         <a href="{{ url_for('delete_meeting',
-            meeting_id=meeting.meeting_id) }}{% if from_date %}?from_date={{ from_date }}{% endif %}">
+            meeting_id=org_meeting.meeting_id) }}{% if from_date %}?from_date={{ from_date }}{% endif %}">
             <img src="{{ url_for('static', filename='delete.png') }}"
                 title="{{ _('Delete') }}" alt="{{ _('Delete') }}"/>
         </a>


### PR DESCRIPTION
We were using the next_meeting object that we did not update for timezone
information, so this lead to glitches such as the one reported at:
https://fedorahosted.org/fedocal/ticket/160
With this change, we update the next_meeting update for the timezone of
interest.

While doing so, we realized that the meeting object was basically
un-needed, we do not really use it and there is not much interest in
keeping it around. So we are removing it and relying on the orig_meeting
object (original meeting) when we need some information.