### PR TITLE
Drop the use of flask.ext to import flask_babel

### DIFF
--- a/fedocal/__init__.py
+++ b/fedocal/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
- (c) 2012-2016 - Copyright Pierre-Yves Chibon <pingou@pingoured.fr>
+ (c) 2012-2017 - Copyright Pierre-Yves Chibon <pingou@pingoured.fr>
 
  Distributed under License GPLv3 or later
  You can find a copy of this license on the website
@@ -157,7 +157,7 @@ def get_locale():
     """try to guess the language from the user accept
     header the browser transmits"""
     try:
-        import flask.ext.babel
+        import flask_babel
         return flask.request.accept_languages.best_match(
             APP.config['LANGUAGES'].keys()
         )

--- a/fedocal/fedocal_babel.py
+++ b/fedocal/fedocal_babel.py
@@ -3,7 +3,7 @@
 """
  (c) 2014 - Copyright Johan Cwiklinski <johan@x-tnd.be>
  (c) 2014 - Copyright Patrick Uiterwijk <puiterwijk@redhat.com>
- (c) 2014 - Copyright Pierre-Yves Chibon <pingou@pingoured.fr>
+ (c) 2014-2017 - Copyright Pierre-Yves Chibon <pingou@pingoured.fr>
 
  Distributed under License GPLv3 or later
  You can find a copy of this license on the website
@@ -28,7 +28,7 @@
 from babel import support
 
 try:
-    from flask.ext.babel import (
+    from flask_babel import (
         Babel, lazy_gettext, gettext, ngettext, format_datetime, get_locale)
 except ImportError:
 


### PR DESCRIPTION
Using flask.ext is now deprecated and its support will be dropped in
future releases of flask. With this commit we no longer rely on this
mechanism and simply import the extension via ``import flask_babel``