### PR TITLE
Do not convert the meeting time-zone twice

### DIFF
--- a/fedocal/__init__.py
+++ b/fedocal/__init__.py
@@ -1095,7 +1095,7 @@ def view_meeting_page(meeting_id, full):
     next_meeting = fedocallib.update_date_rec_meeting(
         meeting_utc, action='next', date_limit=date_limit)
     next_meeting = fedocallib.convert_meeting_timezone(
-        next_meeting, next_meeting.meeting_timezone, tzone)
+        next_meeting, 'UTC', tzone)
 
     return flask.render_template(
         'view_meeting.html',


### PR DESCRIPTION
The ordering goes like this:
- Get the original meeting object from the DB
- Convert it to UTC (becomes: meeting_utc)
- Get the next meeting depending on its recursivity, using meeting_utc
 (becomes: next_meeting)
- Convert to the user's timezone.

The bug was that we were converting next_meeting to the user's timezone
based on the timezone of the original meeting, but next_meeting is based
on meeting_utc, so it is already in UTC and therefore we need to convert
its timezone from UTC.