### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/alembic/update03_to_04.py
+++ b/alembic/update03_to_04.py
@@ -32,6 +32,7 @@ Note: It will need the SQLAlchemy database url filled at the top of this
 file.
 
 '''
+from __future__ import print_function
 
 ## These two lines are needed to run on EL6
 __requires__ = ['SQLAlchemy >= 0.7', 'jinja2 >= 2.4']
@@ -107,7 +108,7 @@ def convert_calendars(fed03_sess, fed04_sess):
         fed04_sess.add(calendarobj)
         cnt += 1
     fed04_sess.commit()
-    print '%s calendars added' % cnt
+    print('%s calendars added' % cnt)
 
 
 def convert_reminders(fed03_sess, fed04_sess):
@@ -124,7 +125,7 @@ def convert_reminders(fed03_sess, fed04_sess):
         fed04_sess.add(reminderobj)
         cnt += 1
     fed04_sess.commit()
-    print '%s reminders added' % cnt
+    print('%s reminders added' % cnt)
 
 
 def convert_meetings(fed03_sess, fed04_sess):
@@ -161,7 +162,7 @@ def convert_meetings(fed03_sess, fed04_sess):
         fed04_sess.flush()
         cnt += 1
     fed04_sess.commit()
-    print '%s meetings added' % cnt
+    print('%s meetings added' % cnt)
 
 
 def main(db_url_fed03, db_url_fed04):
@@ -180,8 +181,8 @@ def main(db_url_fed03, db_url_fed04):
 
 if __name__ == '__main__':
     if not DB_URL_FEDOCAL03 or not DB_URL_FEDOCAL04:
-        print 'You need to set the database(s) URL(s) at the top of this ' \
-              'file'
+        print('You need to set the database(s) URL(s) at the top of this ' \
+              'file')
         sys.exit(1)
 
     main(DB_URL_FEDOCAL03, DB_URL_FEDOCAL04)

--- a/alembic/versions/322997a7a41b_add_calendar_status_table.py
+++ b/alembic/versions/322997a7a41b_add_calendar_status_table.py
@@ -5,6 +5,7 @@ Revises: 4f509700da52
 Create Date: 2013-10-15 11:52:16.185994
 
 """
+from __future__ import print_function
 
 # revision identifiers, used by Alembic.
 revision = '322997a7a41b'
@@ -25,7 +26,7 @@ def upgrade():
                       server_default='Enabled')
             )
     except Exception as e:
-        print e
+        print(e)
 
 
 def downgrade():

--- a/fedocal/__init__.py
+++ b/fedocal/__init__.py
@@ -777,7 +777,7 @@ def add_calendar():
         try:
             calendarobj.save(SESSION)
             SESSION.commit()
-        except SQLAlchemyError, err:
+        except SQLAlchemyError as err:
             SESSION.rollback()
             LOG.debug('Error in add_calendar')
             LOG.exception(err)
@@ -875,12 +875,12 @@ def add_meeting(calendar_name, full=True):
                 remind_who=form.remind_who.data,
                 full_day=form.full_day.data,
                 admin=is_admin())
-        except FedocalException, err:
+        except FedocalException as err:
             flask.flash(str(err), 'warnings')
             return flask.render_template(
                 'add_meeting.html', calendar=calendarobj, form=form,
                 tzone=tzone, full=full)
-        except SQLAlchemyError, err:  # pragma: no cover
+        except SQLAlchemyError as err:  # pragma: no cover
             SESSION.rollback()
             LOG.debug('Error in add_meeting')
             LOG.exception(err)
@@ -1010,12 +1010,12 @@ def edit_meeting(meeting_id):
                 full_day=form.full_day.data,
                 edit_all_meeting=action == 'Save all',
                 admin=is_admin())
-        except FedocalException, err:
+        except FedocalException as err:
             flask.flash(err, 'warnings')
             return flask.render_template(
                 'edit_meeting.html', meeting=meeting, calendar=calendarobj,
                 form=form, tzone=tzone)
-        except SQLAlchemyError, err:  # pragma: no cover
+        except SQLAlchemyError as err:  # pragma: no cover
             SESSION.rollback()
             LOG.debug('Error in edit_meeting')
             LOG.exception(err)
@@ -1188,7 +1188,7 @@ def delete_meeting(meeting_id):
                     calendar=meeting.calendar.to_json(),
                 ))
                 flask.flash(gettext('Meeting deleted'))
-            except SQLAlchemyError, err:  # pragma: no cover
+            except SQLAlchemyError as err:  # pragma: no cover
                 SESSION.rollback()
                 LOG.debug('Error in delete_meeting - 2')
                 LOG.exception(err)
@@ -1248,7 +1248,7 @@ def delete_calendar(calendar_name):
                     agent=flask.g.fas_user.username,
                     calendar=calendarobj.to_json(),
                 ))
-            except SQLAlchemyError, err:  # pragma: no cover
+            except SQLAlchemyError as err:  # pragma: no cover
                 SESSION.rollback()
                 LOG.debug('Error in delete_calendar')
                 LOG.exception(err)
@@ -1291,7 +1291,7 @@ def clear_calendar(calendar_name):
                 fedocallib.clear_calendar(SESSION, calendarobj)
                 SESSION.commit()
                 flask.flash(gettext('Calendar cleared'))
-            except SQLAlchemyError, err:  # pragma: no cover
+            except SQLAlchemyError as err:  # pragma: no cover
                 SESSION.rollback()
                 LOG.debug('Error in clear_calendar')
                 LOG.exception(err)
@@ -1348,7 +1348,7 @@ def edit_calendar(calendar_name):
             calendarobj.calendar_status = form.calendar_status.data
             calendarobj.save(SESSION)
             SESSION.commit()
-        except SQLAlchemyError, err:  # pragma: no cover
+        except SQLAlchemyError as err:  # pragma: no cover
             SESSION.rollback()
             LOG.debug('Error in edit_calendar')
             LOG.exception(err)
@@ -1742,7 +1742,7 @@ def upload_calendar(calendar_name):
             flask.flash(err.message, 'error')
             return flask.render_template(
                 'upload_calendar.html', form=form, calendar=calendarobj)
-        except SQLAlchemyError, err:  # pragma: no cover
+        except SQLAlchemyError as err:  # pragma: no cover
             SESSION.rollback()
             LOG.debug('Error in upload_calendar')
             LOG.exception(err)

--- a/fedocal/api.py
+++ b/fedocal/api.py
@@ -412,7 +412,7 @@ Filter arguments
                 for calendar in fedocallib.get_calendars(SESSION):
                     meetings.extend(fedocallib.get_by_date(
                         SESSION, calendar, startd, endd))
-    except SQLAlchemyError, err:  # pragma: no cover
+    except SQLAlchemyError as err:  # pragma: no cover
         status = 500
         LOG.debug('Error in api_meetings')
         LOG.exception(err)

--- a/fedocal/fedocallib/fedmsgshim.py
+++ b/fedocal/fedocallib/fedmsgshim.py
@@ -13,5 +13,5 @@ def publish(*args, **kwargs):  # pragma: no cover
     try:
         import fedmsg
         fedmsg.publish(*args, **kwargs)
-    except Exception, err:
+    except Exception as err:
         warnings.warn(str(err))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -26,6 +26,7 @@
 
  fedocal.model test script
 """
+from __future__ import print_function
 
 __requires__ = ['SQLAlchemy >= 0.7']
 import pkg_resources
@@ -58,7 +59,7 @@ if os.environ.get('BUILD_ID'):
         req = requests.get('%s/new' % FAITOUT_URL)
         if req.status_code == 200:
             DB_PATH = req.text
-            print 'Using faitout at: %s' % DB_PATH
+            print('Using faitout at: %s' % DB_PATH)
     except:
         pass
 

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -26,6 +26,7 @@
 
  fedocal.model test script
 """
+from __future__ import print_function
 
 __requires__ = ['SQLAlchemy >= 0.7', 'jinja2 >= 2.4']
 import pkg_resources
@@ -1328,7 +1329,7 @@ class Flasktests(Modeltests):
         with user_set(fedocal.APP, user):
             output = self.app.get('/calendar_test/add/', follow_redirects=True)
             self.assertEqual(output.status_code, 200)
-            print output.data
+            print(output.data)
             self.assertTrue(
                 '"errors">No calendar named calendar_test could be found</'
                 in output.data)


### PR DESCRIPTION
* Use __print()__ function in both Python 2 and Python 3
    * __print()__ is a function in Python 3.
* Old style exceptions --> new style in Python 3
    * Python 3 treats old style exceptions as syntax errors but new style exceptions work as expected in both Python 2 and Python 3.