### PR TITLE
Fix mention of Freenode, since we moved to Libera

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -27,5 +27,5 @@ If you're submitting patches to fedocal, please observe the following:
    idea but don't know how to implement it, you just have something bugging
    you?
 
-   Come to see us on IRC: ``#fedora-apps`` on irc.freenode.net or via the
+   Come to see us on IRC: ``#fedora-apps`` on irc.libera.chat or via the
    `issue tracker of the project <https://pagure.io/fedocal/>`_.

--- a/fedocal/api.py
+++ b/fedocal/api.py
@@ -193,7 +193,7 @@ Sample response:
     {
         "locations": [
             "EMEA",
-            "#fedora-meeting@irc.freenode.net"
+            "#fedora-meeting@irc.libera.chat"
         ]
     }
     """


### PR DESCRIPTION
While fixing the docstring is not strictly necessary, we
are not the ones who decided to salt the earth in the first place.